### PR TITLE
Update requirements.txt

### DIFF
--- a/analyzers/Elasticsearch/requirements.txt
+++ b/analyzers/Elasticsearch/requirements.txt
@@ -1,5 +1,6 @@
-elasticsearch>=8.0.0
+elasticsearch>=8.0.0,<9.0.0
 cortexutils
 pytz
 requests
+
 python-dateutil


### PR DESCRIPTION
Version 9.x of python library for ES does change the signature for the Elasticsearch class.

In particular, the `timeout` params has been completely substituted with `request_timeout`.

This patch is a workaround for pinning the requirements. In an upcoming PR both version will be supported.